### PR TITLE
Ensure the AS name is UTF-8 encoded

### DIFF
--- a/flow-exporter.go
+++ b/flow-exporter.go
@@ -102,7 +102,7 @@ func fetchASDatabase() map[int]string {
 			panic(err)
 		}
 
-		asns[asn] = parsedASN[2]
+		asns[asn] = strings.ToValidUTF8(parsedASN[2], "")
 	}
 
 	return asns


### PR DESCRIPTION
As of Go 1.13, it looks like there is now a [`strings.ToValidUTF8`](https://golang.org/pkg/strings/#ToValidUTF8) function that should be able to strip out invalid UTF8 characters. There are probably better solutions, but this seems Good Enough™ for now.

##

Fixes #1.