### PR TITLE
Update AS regex to not accidentally stop on spaces

### DIFF
--- a/flow-exporter.go
+++ b/flow-exporter.go
@@ -92,7 +92,7 @@ func fetchASDatabase() map[int]string {
 			continue
 		}
 
-		parsedASN := regexp.MustCompile(`([\d]+)\s+([\w+_-]+).*`).FindStringSubmatch(rawASN)
+		parsedASN := regexp.MustCompile(`([\d]+)\s+(.*),\s(\w{2})`).FindStringSubmatch(rawASN)
 		if parsedASN == nil {
 			continue
 		}


### PR DESCRIPTION
Prior to this pull request, the following string from the [AS name database](http://www.cidr-report.org/as2.0/asn.txt):

```
12876	Online SAS, FR
```

Would be parsed as `Online`. Now with this new regex, `Online SAS` will be returned.