### PR TITLE
Allow AS0 to be used

### DIFF
--- a/cmd/flow-exporter/main.go
+++ b/cmd/flow-exporter/main.go
@@ -22,9 +22,13 @@ var (
 func main() {
 	flag.Parse()
 
-	if *brokers == "" || *topic == "" || *asn == 0 {
+	if *brokers == "" || *topic == "" {
 		flag.PrintDefaults()
 		os.Exit(1)
+	}
+
+	if *asn == 0 {
+		log.Info("No ASN set, defaulting to AS0. This will lead to inaccurate data, be sure to set the ASN in the --asn argument")
 	}
 
 	log.Info("Fetching up to date AS database")


### PR DESCRIPTION
In #11, we saw that it's not possible to debug the application by setting `--asn=0`.

This pull request updates the command line arguments to allow for `--asn=0` (or no `asn` argument at all), and offers a disclaimer to users that we may end up with inaccurate data when doing this (more information as to why can be found [here](https://www.mail-archive.com/pmacct-discussion@pmacct.net/msg03864.html)), but to quote @paololucente:

> with an iBGP peering setup, AS0 can mean unknown or your own ASN (being a number rather than a string, null is not an option) and 2) until routes are received, source/destination IP prefixes can get associated to AS0.