### PR TITLE
feature: add source/destination network metric labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The exporter can be started with:
 ./flow-exporter --brokers=kafka.fqdn.com:9092 --topic=pmacct.acct --asn=15169
 ```
 
+- `--addr`: Listening address (default = :9590)
 - `--brokers`: A comma separated list of Kafka brokers (with their corresponding ports) to consume flows from
 - `--topic`: The Kafka topic to consume flows from
 - `--asn`: The autonomous system number that the flows are being monitored from
@@ -27,11 +28,11 @@ An example of the Prometheus metrics you can find are:
 ```
 # HELP flow_receive_bytes_total Bytes received.
 # TYPE flow_receive_bytes_total counter
-flow_receive_bytes_total{destination_as="397143",destination_as_name="NEPTUNE-NETWORKS - Neptune Networks",hostname="border.neptunenetworks.org",source_as="10318",source_as_name="CABLEVISION S.A."} 663
+flow_receive_bytes_total{destination_as="397143",destination_as_name="NEPTUNE-NETWORKS - Neptune Networks",dst_net="2a0b:b7c4::/30",hostname="border.neptunenetworks.org",source_as="10318",source_as_name="CABLEVISION S.A.",src_net="2a0e:8f02:f017::/48"} 663
 
 # HELP flow_transmit_bytes_total Bytes transferred.
 # TYPE flow_transmit_bytes_total counter
-flow_transmit_bytes_total{destination_as="10318",destination_as_name="CABLEVISION S.A.",hostname="border.neptunenetworks.org",source_as="397143",source_as_name="NEPTUNE-NETWORKS - Neptune Networks"} 1137
+flow_transmit_bytes_total{destination_as="10318",destination_as_name="CABLEVISION S.A.",dst_net="2a0b:b7c4::/30",hostname="border.neptunenetworks.org",source_as="397143",source_as_name="NEPTUNE-NETWORKS - Neptune Networks",src_net="2a0e:8f02:f017::/48"} 1137
 ```
 
 Flow Exporter automatically finds the name of the ASN and adds it to the metric.
@@ -45,6 +46,10 @@ Flow exporter requires a Kafka topic that has events which contain the following
   "label": "bdr1.fqdn.com",
   "as_src": 15169,
   "as_dst": 6939,
+  "net_src": "2a0e:8f02:f017::",
+  "net_dst": "2a0b:b7c4::",
+  "mask_src": 48,
+  "mask_dst": 30,
   "bytes": 52,
 }
 ```
@@ -53,6 +58,10 @@ Flow exporter requires a Kafka topic that has events which contain the following
 - `as_src`: The ASN that originated the flow
 - `as_dst`: The ASN that the flow was destined for
 - `bytes`: The number of bytes contained in the flow
+- `net_src`: Source subnet of the flow
+- `net_dst`: Destination subnet of the flow
+- `mask_src`: Netmask of the source subnet
+- `mask_dst`: Netmask of the destination subnet
 
 ## [pmacct](https://github.com/pmacct/pmacct) Integration
 
@@ -82,7 +91,7 @@ bgp_agent_map: /etc/pmacct/peering_agent.map
 networks_file: /etc/pmacct/networks.lst
 networks_file_no_lpm: true
 !
-aggregate: src_host, dst_host, src_port, dst_port, src_as, dst_as, label
+aggregate: net_src, net_dst, mask_src, mask_dst, src_port, dst_port, src_as, dst_as, label
 !
 plugins: kafka
 kafka_output: json
@@ -135,8 +144,8 @@ The application can be compiled by running:
 
 ```
 git clone https://github.com/neptune-networks/flow-exporter
-cd flow-exporter
-go build
+cd flow-exporter/cmd/flow-exporter
+go build main.go
 ```
 
 ## Releasing

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Shopify/sarama"
+	"github.com/IBM/sarama"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
@@ -20,7 +20,7 @@ var (
 			Name: "flow_receive_bytes_total",
 			Help: "Bytes received.",
 		},
-		[]string{"source_as", "source_as_name", "destination_as", "destination_as_name", "hostname"},
+		[]string{"source_as", "source_as_name", "destination_as", "destination_as_name", "hostname", "src_net", "dst_net"},
 	)
 
 	flowTransmitBytesTotal = promauto.NewCounterVec(
@@ -28,17 +28,19 @@ var (
 			Name: "flow_transmit_bytes_total",
 			Help: "Bytes transferred.",
 		},
-		[]string{"source_as", "source_as_name", "destination_as", "destination_as_name", "hostname"},
+		[]string{"source_as", "source_as_name", "destination_as", "destination_as_name", "hostname", "src_net", "dst_net"},
 	)
 )
 
 type flow struct {
 	SourceAS      int    `json:"as_src"`
 	DestinationAS int    `json:"as_dst"`
-	SourceIP      string `json:"ip_dst"`
-	DestinationIP string `json:"ip_src"`
 	Bytes         int    `json:"bytes"`
 	Hostname      string `json:"label"`
+	SourceNET     string `json:"net_src"`
+	DestinationNET   string `json:"net_dst"`
+	SourceMask       int    `json:"mask_src"`
+	DestinationMask  int    `json:"mask_dst"`
 }
 
 // Consume ...
@@ -132,6 +134,8 @@ func logFlow(message sarama.ConsumerMessage, asns map[int]string, asn int) {
 				"destination_as":      strconv.Itoa(f.DestinationAS),
 				"destination_as_name": asns[f.DestinationAS],
 				"hostname":            f.Hostname,
+				"src_net":             f.SourceNET + "/" + strconv.Itoa(f.SourceMask),
+				"dst_net":			   f.DestinationNET + "/" + strconv.Itoa(f.DestinationMask),
 			},
 		).Add(float64(f.Bytes))
 	} else if f.DestinationAS == asn {
@@ -142,6 +146,8 @@ func logFlow(message sarama.ConsumerMessage, asns map[int]string, asn int) {
 				"destination_as":      strconv.Itoa(f.DestinationAS),
 				"destination_as_name": asns[f.DestinationAS],
 				"hostname":            f.Hostname,
+				"src_net":             f.SourceNET + "/" + strconv.Itoa(f.SourceMask),
+				"dst_net":             f.DestinationNET + "/" + strconv.Itoa(f.DestinationMask),
 			},
 		).Add(float64(f.Bytes))
 	}

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/IBM/sarama"
+	"github.com/Shopify/sarama"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"


### PR DESCRIPTION
Using only prefixes instead of full IPs reduces the load on prometheus. I will add updates to the readme later to this pr.
Also im working on adding port metrics/labels, but that will be a second PR.  